### PR TITLE
upgr geotools to latest version before new JTS to fix GeometryUtilsTest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
       <jerseyframework.version>2.7</jerseyframework.version>
       <jetty.version>9.4.17.v20190418</jetty.version>      	  
       <jackson.version>[2.9.10.4,)</jackson.version>
-      <geotools.version>18.1</geotools.version>
+      <geotools.version>19.4</geotools.version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
Fikk følgende feil i GeometryUtilsTest som blir fikset av denne oppgraderingen.
```
Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.197 sec <<< FAILURE! - in no.geonorge.nedlasting.utils.GeometryUtilsTest
testArea(no.geonorge.nedlasting.utils.GeometryUtilsTest)  Time elapsed: 0.175 sec  <<< ERROR!
java.lang.IllegalArgumentException: org.opengis.referencing.datum.DatumFactory is not an ImageIO SPI class
	at no.geonorge.nedlasting.utils.GeometryUtilsTest.testArea(GeometryUtilsTest.java:22)
```

Egentlig burde vi kanskje oppgradere GeoTools til en versjon > 20, men da er det ny JTS med nye pakkenavn så det er litt større endring. Foreslår derfor denne mini-oppgraderingen først.

Hva tror du, @bgrotan ?