### PR TITLE
add jaxb to fix ClassNotFoundException: javax.xml.bind.UnmarshalException

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,12 @@
         <artifactId>jackson-databind</artifactId>
         <version>${jackson.version}</version>
     </dependency>
+    
+    <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+        <version>2.3.1</version>
+    </dependency>
       
     <dependency>
         <groupId>org.glassfish.jersey.containers</groupId>


### PR DESCRIPTION
La til jaxb for å fjerne meldinger ala denne ved kjøring av `mvn test`.

```
WARNING: The following warnings have been detected: WARNING: HK2 service reification failed for [org.glassfish.jersey.moxy.json.internal.ConfigurableMoxyJsonProvider] with an exception:
MultiException stack 1 of 2
java.lang.NoClassDefFoundError: javax/xml/bind/UnmarshalException
	at java.base/java.lang.Class.getDeclaredConstructors0(Native Method)
	at java.base/java.lang.Class.privateGetDeclaredConstructors(Class.java:3138)
	at java.base/java.lang.Class.getDeclaredConstructors(Class.java:2358)
	at org.jvnet.hk2.internal.Utilities$7.run(Utilities.java:1316)
	at org.jvnet.hk2.internal.Utilities$7.run(Utilities.java:1312)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:312)
	at org.jvnet.hk2.internal.Utilities.getAllConstructors(Utilities.java:1312)
	at org.jvnet.hk2.internal.Utilities.findProducerConstructor(Utilities.java:1233)
	at org.jvnet.hk2.internal.DefaultClassAnalyzer.getConstructor(DefaultClassAnalyzer.java:78)
	at org.glassfish.jersey.internal.inject.JerseyClassAnalyzer.getConstructor(JerseyClassAnalyzer.java:143)
	at org.jvnet.hk2.internal.Utilities.getConstructor(Utilities.java:203)
	at org.jvnet.hk2.internal.ClazzCreator.initialize(ClazzCreator.java:147)
	at org.jvnet.hk2.internal.ClazzCreator.initialize(ClazzCreator.java:200)
	at org.jvnet.hk2.internal.SystemDescriptor.internalReify(SystemDescriptor.java:649)
	at org.jvnet.hk2.internal.SystemDescriptor.reify(SystemDescriptor.java:604)
	at org.jvnet.hk2.internal.ServiceLocatorImpl.reifyDescriptor(ServiceLocatorImpl.java:405)
	at org.jvnet.hk2.internal.ServiceLocatorImpl.narrow(ServiceLocatorImpl.java:2046)
	at org.jvnet.hk2.internal.ServiceLocatorImpl.access$700(ServiceLocatorImpl.java:116)
	at org.jvnet.hk2.internal.ServiceLocatorImpl$8.compute(ServiceLocatorImpl.java:1207)
	at org.jvnet.hk2.internal.ServiceLocatorImpl$8.compute(ServiceLocatorImpl.java:1202)
	at org.glassfish.hk2.utilities.cache.LRUHybridCache$OriginThreadAwareFuture$1.call(LRUHybridCache.java:115)
	at org.glassfish.hk2.utilities.cache.LRUHybridCache$OriginThreadAwareFuture$1.call(LRUHybridCache.java:111)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at org.glassfish.hk2.utilities.cache.LRUHybridCache$OriginThreadAwareFuture.run(LRUHybridCache.java:173)
	at org.glassfish.hk2.utilities.cache.LRUHybridCache.compute(LRUHybridCache.java:292)
	at org.jvnet.hk2.internal.ServiceLocatorImpl.internalGetAllServiceHandles(ServiceLocatorImpl.java:1280)
	at org.jvnet.hk2.internal.ServiceLocatorImpl.getAllServiceHandles(ServiceLocatorImpl.java:1189)
	at org.jvnet.hk2.internal.ServiceLocatorImpl.getAllServiceHandles(ServiceLocatorImpl.java:1178)
	at org.glassfish.jersey.internal.inject.Providers.getAllServiceHandles(Providers.java:314)
	at org.glassfish.jersey.internal.inject.Providers.getCustomProviders(Providers.java:199)
	at org.glassfish.jersey.message.internal.MessageBodyFactory.<init>(MessageBodyFactory.java:303)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:500)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:481)
	at org.glassfish.hk2.utilities.reflection.ReflectionHelper.makeMe(ReflectionHelper.java:1105)
	at org.jvnet.hk2.internal.ClazzCreator.createMe(ClazzCreator.java:292)
	at org.jvnet.hk2.internal.ClazzCreator.create(ClazzCreator.java:422)
	at org.jvnet.hk2.internal.SystemDescriptor.create(SystemDescriptor.java:456)
	at org.jvnet.hk2.internal.SingletonContext$1.compute(SingletonContext.java:114)
	at org.jvnet.hk2.internal.SingletonContext$1.compute(SingletonContext.java:102)
	at org.glassfish.hk2.utilities.cache.Cache$OriginThreadAwareFuture$1.call(Cache.java:97)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at org.glassfish.hk2.utilities.cache.Cache$OriginThreadAwareFuture.run(Cache.java:154)
	at org.glassfish.hk2.utilities.cache.Cache.compute(Cache.java:199)
	at org.jvnet.hk2.internal.SingletonContext.findOrCreate(SingletonContext.java:153)
	at org.jvnet.hk2.internal.Utilities.createService(Utilities.java:2445)
	at org.jvnet.hk2.internal.ServiceLocatorImpl.getService(ServiceLocatorImpl.java:621)
	at org.jvnet.hk2.internal.IterableProviderImpl.get(IterableProviderImpl.java:107)
	at org.glassfish.jersey.client.RequestProcessingInitializationStage.apply(RequestProcessingInitializationStage.java:97)
	at org.glassfish.jersey.client.RequestProcessingInitializationStage.apply(RequestProcessingInitializationStage.java:67)
	at org.glassfish.jersey.process.internal.Stages$LinkedStage.apply(Stages.java:308)
	at org.glassfish.jersey.process.internal.Stages.process(Stages.java:171)
	at org.glassfish.jersey.client.ClientRuntime.invoke(ClientRuntime.java:225)
	at org.glassfish.jersey.client.JerseyInvocation$2.call(JerseyInvocation.java:671)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:315)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:297)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:228)
	at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:424)
	at org.glassfish.jersey.client.JerseyInvocation.invoke(JerseyInvocation.java:667)
	at org.glassfish.jersey.client.JerseyInvocation$Builder.method(JerseyInvocation.java:396)
	at org.glassfish.jersey.client.JerseyInvocation$Builder.get(JerseyInvocation.java:296)
	at no.geonorge.rest.DownloadService.createResponseFromRemoteFile(DownloadService.java:486)
	at no.geonorge.rest.DownloadService.getFileForDownload(DownloadService.java:458)
	at no.geonorge.rest.DownloadServiceTest.testGetFileForDownload(DownloadServiceTest.java:317)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:567)
	at junit.framework.TestCase.runTest(TestCase.java:176)
	at junit.framework.TestCase.runBare(TestCase.java:141)
	at junit.framework.TestResult$1.protect(TestResult.java:122)
	at junit.framework.TestResult.runProtected(TestResult.java:142)
	at junit.framework.TestResult.run(TestResult.java:125)
	at junit.framework.TestCase.run(TestCase.java:129)
	at junit.framework.TestSuite.runTest(TestSuite.java:252)
	at junit.framework.TestSuite.run(TestSuite.java:247)
	at org.junit.internal.runners.JUnit38ClassRunner.run(JUnit38ClassRunner.java:86)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:367)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:274)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:238)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:161)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:290)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:242)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:121)
Caused by: java.lang.ClassNotFoundException: javax.xml.bind.UnmarshalException
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:602)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
	... 86 more
```