### PR TITLE
downgrade to a new jetty 9 to fix compile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
       <maven.compile.source>1.8</maven.compile.source>
       <maven.compile.target>1.8</maven.compile.target>
       <jerseyframework.version>2.7</jerseyframework.version>
-      <jetty.version>11.0.7</jetty.version>      	  
+      <jetty.version>9.4.45.v20220203</jetty.version>
       <jackson.version>[2.9.10.4,)</jackson.version>
       <geotools.version>19.4</geotools.version>
   </properties>


### PR DESCRIPTION
Denne fikser kompilering. For å gå til jetty 10 må man ha nyere java og for å gå til jetty 11 må man i tillegg bytte servlet api pakke navn. Det kan utsettes ettersom jetty 9 fortsatt får sikkerhetsfikser.